### PR TITLE
Refactor and ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: required
+services:
+  - docker
+script:
+  - ./ci_script.sh

--- a/ci_script.sh
+++ b/ci_script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -v $PWD/workdir:/srv/workdir -w /srv/workdir hiogawa/i686-elf:4.9.3 make myos.bin

--- a/workdir/boot.s
+++ b/workdir/boot.s
@@ -75,10 +75,10 @@ isr0:
 
 isr_common_stub:
 	pusha
-	# the 1st argument of `fault_handler` will be a pointer to current stack top
+	# the 1st argument of `isr_main` will be a pointer to current stack top
 	push %esp
 	cld
-	call fault_handler
+	call isr_main
 	add $4, %esp
 	popa
 	add $8, %esp

--- a/workdir/isrs.c
+++ b/workdir/isrs.c
@@ -9,7 +9,7 @@ char *exception_messages[] = {
   "WTF"
 };
 
-void fault_handler(struct regs *r) {
+void isr_main(struct regs *r) {
   puts("Exception is handled!\n");
   // show as ascii (numbers starts from 0d48)
   puts("r->int_no : "); putchar(r->int_no + 48); putchar('\n');


### PR DESCRIPTION
docker image is what I made here: https://hub.docker.com/r/hiogawa/i686-elf/.
it doesn't include `grub-mkrescue` so this ci script only make sure `myos.bin` is buildable.
